### PR TITLE
Separate labels from numbers to reduce strings to translate

### DIFF
--- a/7i76e/src/7i76e.ui
+++ b/7i76e/src/7i76e.ui
@@ -6078,115 +6078,195 @@ QGroupBox::title {
            <string>Outputs TB5 Pins 17-24</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_51">
-           <item row="0" column="0">
+           <item row="0" column="1">
             <widget class="QLabel" name="label_433">
              <property name="text">
-              <string>Output 8</string>
+              <string>8</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item row="1" column="1">
             <widget class="QLabel" name="label_434">
              <property name="text">
-              <string>Output 9</string>
+              <string>9</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="2" column="1">
             <widget class="QLabel" name="label_430">
              <property name="text">
-              <string>Output 10</string>
+              <string>10</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
+           <item row="3" column="1">
             <widget class="QLabel" name="label_432">
              <property name="text">
-              <string>Output 11</string>
+              <string>11</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
+           <item row="4" column="1">
             <widget class="QLabel" name="label_428">
              <property name="text">
-              <string>Output 12</string>
+              <string>12</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
+           <item row="5" column="1">
             <widget class="QLabel" name="label_431">
              <property name="text">
-              <string>Output 13</string>
+              <string>13</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="0">
+           <item row="6" column="1">
             <widget class="QLabel" name="label_429">
              <property name="text">
-              <string>Output 14</string>
+              <string>14</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="0">
+           <item row="7" column="1">
             <widget class="QLabel" name="label_427">
              <property name="text">
-              <string>Output 15</string>
+              <string>15</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item row="0" column="2">
             <widget class="QPushButton" name="outputPB_8">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="1" column="2">
             <widget class="QPushButton" name="outputPB_9">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
+           <item row="2" column="2">
             <widget class="QPushButton" name="outputPB_10">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
+           <item row="3" column="2">
             <widget class="QPushButton" name="outputPB_11">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="1">
+           <item row="4" column="2">
             <widget class="QPushButton" name="outputPB_12">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="1">
+           <item row="5" column="2">
             <widget class="QPushButton" name="outputPB_13">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="1">
+           <item row="6" column="2">
             <widget class="QPushButton" name="outputPB_14">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="1">
+           <item row="7" column="2">
             <widget class="QPushButton" name="outputPB_15">
              <property name="text">
               <string>Select</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_902">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_910">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_911">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_912">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_913">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_914">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="label_915">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="label_916">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
@@ -6213,115 +6293,195 @@ QGroupBox::title {
            <string>Outputs TB6 Pins 17-24</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_45">
-           <item row="0" column="0">
+           <item row="0" column="1">
             <widget class="QLabel" name="label_22">
              <property name="text">
-              <string>Output 0</string>
+              <string>0</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item row="1" column="1">
             <widget class="QLabel" name="label_23">
              <property name="text">
-              <string>Output 1</string>
+              <string>1</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="2" column="1">
             <widget class="QLabel" name="label_24">
              <property name="text">
-              <string>Output 2</string>
+              <string>2</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
+           <item row="3" column="1">
             <widget class="QLabel" name="label_25">
              <property name="text">
-              <string>Output 3</string>
+              <string>3</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
+           <item row="4" column="1">
             <widget class="QLabel" name="label_26">
              <property name="text">
-              <string>Output 4</string>
+              <string>4</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
+           <item row="5" column="1">
             <widget class="QLabel" name="label_293">
              <property name="text">
-              <string>Output 5</string>
+              <string>5</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="0">
+           <item row="7" column="1">
             <widget class="QLabel" name="label_425">
              <property name="text">
-              <string>Output 7</string>
+              <string>7</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="0">
+           <item row="6" column="1">
             <widget class="QLabel" name="label_426">
              <property name="text">
-              <string>Output 6</string>
+              <string>6</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item row="0" column="2">
             <widget class="QPushButton" name="outputPB_0">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="1" column="2">
             <widget class="QPushButton" name="outputPB_1">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
+           <item row="2" column="2">
             <widget class="QPushButton" name="outputPB_2">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
+           <item row="3" column="2">
             <widget class="QPushButton" name="outputPB_3">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="1">
+           <item row="4" column="2">
             <widget class="QPushButton" name="outputPB_4">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="1">
+           <item row="5" column="2">
             <widget class="QPushButton" name="outputPB_5">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="1">
+           <item row="6" column="2">
             <widget class="QPushButton" name="outputPB_6">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="1">
+           <item row="7" column="2">
             <widget class="QPushButton" name="outputPB_7">
              <property name="text">
               <string>Select</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_901">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_907">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="label_908">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="label_909">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_906">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_905">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_904">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_903">
+             <property name="text">
+              <string>Output</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
@@ -6361,346 +6521,458 @@ QGroupBox::title {
            <string>Inputs TB5 Pins 1-16</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_50">
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_54">
+           <item row="6" column="0">
+            <widget class="QLabel" name="label_888">
              <property name="text">
-              <string>Input 16</string>
+              <string>Input</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="2">
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_54">
+             <property name="text">
+              <string>16</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
             <widget class="QLabel" name="label_359">
              <property name="text">
               <string>Type</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
+           <item row="5" column="1">
             <widget class="QLabel" name="label_361">
              <property name="text">
-              <string>Input 18</string>
+              <string>18</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="0">
+           <item row="6" column="1">
             <widget class="QLabel" name="label_411">
              <property name="text">
-              <string>Input 19</string>
+              <string>19</string>
              </property>
             </widget>
            </item>
-           <item row="21" column="0">
+           <item row="21" column="1">
             <widget class="QLabel" name="label_412">
              <property name="text">
-              <string>Input 31</string>
+              <string>31</string>
              </property>
             </widget>
            </item>
-           <item row="14" column="0">
+           <item row="14" column="1">
             <widget class="QLabel" name="label_413">
              <property name="text">
-              <string>Input 26</string>
+              <string>26</string>
              </property>
             </widget>
            </item>
-           <item row="8" column="0">
+           <item row="8" column="1">
             <widget class="QLabel" name="label_414">
              <property name="text">
-              <string>Input 20</string>
+              <string>20</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
+           <item row="4" column="1">
             <widget class="QLabel" name="label_415">
              <property name="text">
-              <string>Input 17</string>
+              <string>17</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="0">
+           <item row="9" column="1">
             <widget class="QLabel" name="label_416">
              <property name="text">
-              <string>Input 21</string>
+              <string>21</string>
              </property>
             </widget>
            </item>
-           <item row="10" column="0">
+           <item row="10" column="1">
             <widget class="QLabel" name="label_417">
              <property name="text">
-              <string>Input 22</string>
+              <string>22</string>
              </property>
             </widget>
            </item>
-           <item row="11" column="0">
+           <item row="11" column="1">
             <widget class="QLabel" name="label_418">
              <property name="text">
-              <string>Input 23</string>
+              <string>23</string>
              </property>
             </widget>
            </item>
-           <item row="12" column="0">
+           <item row="12" column="1">
             <widget class="QLabel" name="label_419">
              <property name="text">
-              <string>Input 24</string>
+              <string>24</string>
              </property>
             </widget>
            </item>
-           <item row="13" column="0">
+           <item row="13" column="1">
             <widget class="QLabel" name="label_420">
              <property name="text">
-              <string>Input 25</string>
+              <string>25</string>
              </property>
             </widget>
            </item>
-           <item row="16" column="0">
+           <item row="16" column="1">
             <widget class="QLabel" name="label_421">
              <property name="text">
-              <string>Input 27</string>
+              <string>27</string>
              </property>
             </widget>
            </item>
-           <item row="18" column="0">
+           <item row="18" column="1">
             <widget class="QLabel" name="label_422">
              <property name="text">
-              <string>Input 28</string>
+              <string>28</string>
              </property>
             </widget>
            </item>
-           <item row="20" column="0">
+           <item row="20" column="1">
             <widget class="QLabel" name="label_423">
              <property name="text">
-              <string>Input 30</string>
+              <string>30</string>
              </property>
             </widget>
            </item>
-           <item row="19" column="0">
+           <item row="19" column="1">
             <widget class="QLabel" name="label_424">
              <property name="text">
-              <string>Input 29</string>
+              <string>29</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="2">
+           <item row="2" column="3">
             <widget class="QPushButton" name="inputPB_16">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="2">
+           <item row="4" column="3">
             <widget class="QPushButton" name="inputPB_17">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="2">
+           <item row="5" column="3">
             <widget class="QPushButton" name="inputPB_18">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="2">
+           <item row="6" column="3">
             <widget class="QPushButton" name="inputPB_19">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="8" column="2">
+           <item row="8" column="3">
             <widget class="QPushButton" name="inputPB_20">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="2">
+           <item row="9" column="3">
             <widget class="QPushButton" name="inputPB_21">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="10" column="2">
+           <item row="10" column="3">
             <widget class="QPushButton" name="inputPB_22">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="11" column="2">
+           <item row="11" column="3">
             <widget class="QPushButton" name="inputPB_23">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="12" column="2">
+           <item row="12" column="3">
             <widget class="QPushButton" name="inputPB_24">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="13" column="2">
+           <item row="13" column="3">
             <widget class="QPushButton" name="inputPB_25">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="14" column="2">
+           <item row="14" column="3">
             <widget class="QPushButton" name="inputPB_26">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="16" column="2">
+           <item row="16" column="3">
             <widget class="QPushButton" name="inputPB_27">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="18" column="2">
+           <item row="18" column="3">
             <widget class="QPushButton" name="inputPB_28">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="19" column="2">
+           <item row="19" column="3">
             <widget class="QPushButton" name="inputPB_29">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="20" column="2">
+           <item row="20" column="3">
             <widget class="QPushButton" name="inputPB_30">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="21" column="2">
+           <item row="21" column="3">
             <widget class="QPushButton" name="inputPB_31">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="3">
+           <item row="2" column="4">
             <widget class="QCheckBox" name="inputInvertCB_16">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="3">
+           <item row="4" column="4">
             <widget class="QCheckBox" name="inputInvertCB_17">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="3">
+           <item row="5" column="4">
             <widget class="QCheckBox" name="inputInvertCB_18">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="3">
+           <item row="6" column="4">
             <widget class="QCheckBox" name="inputInvertCB_19">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="8" column="3">
+           <item row="8" column="4">
             <widget class="QCheckBox" name="inputInvertCB_20">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="3">
+           <item row="9" column="4">
             <widget class="QCheckBox" name="inputInvertCB_21">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="10" column="3">
+           <item row="10" column="4">
             <widget class="QCheckBox" name="inputInvertCB_22">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="11" column="3">
+           <item row="11" column="4">
             <widget class="QCheckBox" name="inputInvertCB_23">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="12" column="3">
+           <item row="12" column="4">
             <widget class="QCheckBox" name="inputInvertCB_24">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="13" column="3">
+           <item row="13" column="4">
             <widget class="QCheckBox" name="inputInvertCB_25">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="14" column="3">
+           <item row="14" column="4">
             <widget class="QCheckBox" name="inputInvertCB_26">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="16" column="3">
+           <item row="16" column="4">
             <widget class="QCheckBox" name="inputInvertCB_27">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="18" column="3">
+           <item row="18" column="4">
             <widget class="QCheckBox" name="inputInvertCB_28">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="19" column="3">
+           <item row="19" column="4">
             <widget class="QCheckBox" name="inputInvertCB_29">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="20" column="3">
+           <item row="20" column="4">
             <widget class="QCheckBox" name="inputInvertCB_30">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="21" column="3">
+           <item row="21" column="4">
             <widget class="QCheckBox" name="inputInvertCB_31">
              <property name="text">
               <string>Invert</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_886">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_885">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="13" column="0">
+            <widget class="QLabel" name="label_894">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_887">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0">
+            <widget class="QLabel" name="label_891">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="12" column="0">
+            <widget class="QLabel" name="label_893">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="16" column="0">
+            <widget class="QLabel" name="label_896">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="0">
+            <widget class="QLabel" name="label_890">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="14" column="0">
+            <widget class="QLabel" name="label_895">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="11" column="0">
+            <widget class="QLabel" name="label_892">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0">
+            <widget class="QLabel" name="label_889">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="18" column="0">
+            <widget class="QLabel" name="label_897">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="19" column="0">
+            <widget class="QLabel" name="label_898">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="20" column="0">
+            <widget class="QLabel" name="label_899">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="21" column="0">
+            <widget class="QLabel" name="label_900">
+             <property name="text">
+              <string>Input</string>
              </property>
             </widget>
            </item>
@@ -6727,346 +6999,458 @@ QGroupBox::title {
            <string>Inputs TB6 Pins 1-16</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_49">
-           <item row="11" column="0">
+           <item row="11" column="1">
             <widget class="QLabel" name="label_21">
              <property name="text">
-              <string>Input 10</string>
+              <string>10</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="3">
+           <item row="1" column="4">
             <widget class="QCheckBox" name="inputInvertCB_0">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
+           <item row="3" column="1">
             <widget class="QLabel" name="label_13">
              <property name="text">
-              <string>Input 2</string>
+              <string>2</string>
              </property>
             </widget>
            </item>
-           <item row="16" column="0">
+           <item row="16" column="1">
             <widget class="QLabel" name="label_60">
              <property name="text">
-              <string>Input 15</string>
+              <string>15</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
+           <item row="4" column="1">
             <widget class="QLabel" name="label_14">
              <property name="text">
-              <string>Input 3</string>
+              <string>3</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item row="1" column="1">
             <widget class="QLabel" name="label_11">
              <property name="text">
-              <string>Input 0</string>
+              <string>0</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="2">
+           <item row="0" column="3">
             <widget class="QLabel" name="label_28">
              <property name="text">
               <string>Type</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
+           <item row="5" column="1">
             <widget class="QLabel" name="label_15">
              <property name="text">
-              <string>Input 4</string>
+              <string>4</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="2" column="1">
             <widget class="QLabel" name="label_12">
              <property name="text">
-              <string>Input 1</string>
+              <string>1</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="0">
+           <item row="6" column="1">
             <widget class="QLabel" name="label_16">
              <property name="text">
-              <string>Input 5</string>
+              <string>5</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="0">
+           <item row="7" column="1">
             <widget class="QLabel" name="label_17">
              <property name="text">
-              <string>Input 6</string>
+              <string>6</string>
              </property>
             </widget>
            </item>
-           <item row="8" column="0">
+           <item row="8" column="1">
             <widget class="QLabel" name="label_18">
              <property name="text">
-              <string>Input 7</string>
+              <string>7</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="0">
+           <item row="9" column="1">
             <widget class="QLabel" name="label_19">
              <property name="text">
-              <string>Input 8</string>
+              <string>8</string>
              </property>
             </widget>
            </item>
-           <item row="10" column="0">
+           <item row="10" column="1">
             <widget class="QLabel" name="label_20">
              <property name="text">
-              <string>Input 9</string>
+              <string>9</string>
              </property>
             </widget>
            </item>
-           <item row="12" column="0">
+           <item row="12" column="1">
             <widget class="QLabel" name="label_51">
              <property name="text">
-              <string>Input 11</string>
+              <string>11</string>
              </property>
             </widget>
            </item>
-           <item row="13" column="0">
+           <item row="13" column="1">
             <widget class="QLabel" name="label_46">
              <property name="text">
-              <string>Input 12</string>
+              <string>12</string>
              </property>
             </widget>
            </item>
-           <item row="15" column="0">
+           <item row="15" column="1">
             <widget class="QLabel" name="label_358">
              <property name="text">
-              <string>Input 14</string>
+              <string>14</string>
              </property>
             </widget>
            </item>
-           <item row="14" column="0">
+           <item row="14" column="1">
             <widget class="QLabel" name="label_57">
              <property name="text">
-              <string>Input 13</string>
+              <string>13</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="2">
+           <item row="1" column="3">
             <widget class="QPushButton" name="inputPB_0">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="2">
+           <item row="2" column="3">
             <widget class="QPushButton" name="inputPB_1">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="2">
+           <item row="3" column="3">
             <widget class="QPushButton" name="inputPB_2">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="2">
+           <item row="4" column="3">
             <widget class="QPushButton" name="inputPB_3">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="2">
+           <item row="5" column="3">
             <widget class="QPushButton" name="inputPB_4">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="2">
+           <item row="6" column="3">
             <widget class="QPushButton" name="inputPB_5">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="2">
+           <item row="7" column="3">
             <widget class="QPushButton" name="inputPB_6">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="8" column="2">
+           <item row="8" column="3">
             <widget class="QPushButton" name="inputPB_7">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="2">
+           <item row="9" column="3">
             <widget class="QPushButton" name="inputPB_8">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="10" column="2">
+           <item row="10" column="3">
             <widget class="QPushButton" name="inputPB_9">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="11" column="2">
+           <item row="11" column="3">
             <widget class="QPushButton" name="inputPB_10">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="12" column="2">
+           <item row="12" column="3">
             <widget class="QPushButton" name="inputPB_11">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="13" column="2">
+           <item row="13" column="3">
             <widget class="QPushButton" name="inputPB_12">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="14" column="2">
+           <item row="14" column="3">
             <widget class="QPushButton" name="inputPB_13">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="15" column="2">
+           <item row="15" column="3">
             <widget class="QPushButton" name="inputPB_14">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="16" column="2">
+           <item row="16" column="3">
             <widget class="QPushButton" name="inputPB_15">
              <property name="text">
               <string>Select</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="3">
+           <item row="2" column="4">
             <widget class="QCheckBox" name="inputInvertCB_1">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="3">
+           <item row="3" column="4">
             <widget class="QCheckBox" name="inputInvertCB_2">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="3">
+           <item row="4" column="4">
             <widget class="QCheckBox" name="inputInvertCB_3">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="3">
+           <item row="5" column="4">
             <widget class="QCheckBox" name="inputInvertCB_4">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="3">
+           <item row="6" column="4">
             <widget class="QCheckBox" name="inputInvertCB_5">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="3">
+           <item row="7" column="4">
             <widget class="QCheckBox" name="inputInvertCB_6">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="8" column="3">
+           <item row="8" column="4">
             <widget class="QCheckBox" name="inputInvertCB_7">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="3">
+           <item row="9" column="4">
             <widget class="QCheckBox" name="inputInvertCB_8">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="10" column="3">
+           <item row="10" column="4">
             <widget class="QCheckBox" name="inputInvertCB_9">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="11" column="3">
+           <item row="11" column="4">
             <widget class="QCheckBox" name="inputInvertCB_10">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="12" column="3">
+           <item row="12" column="4">
             <widget class="QCheckBox" name="inputInvertCB_11">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="13" column="3">
+           <item row="13" column="4">
             <widget class="QCheckBox" name="inputInvertCB_12">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="14" column="3">
+           <item row="14" column="4">
             <widget class="QCheckBox" name="inputInvertCB_13">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="15" column="3">
+           <item row="15" column="4">
             <widget class="QCheckBox" name="inputInvertCB_14">
              <property name="text">
               <string>Invert</string>
              </property>
             </widget>
            </item>
-           <item row="16" column="3">
+           <item row="16" column="4">
             <widget class="QCheckBox" name="inputInvertCB_15">
              <property name="text">
               <string>Invert</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_8">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_29">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_32">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_198">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_212">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="label_213">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="label_223">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0">
+            <widget class="QLabel" name="label_271">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="0">
+            <widget class="QLabel" name="label_877">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0">
+            <widget class="QLabel" name="label_878">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="11" column="0">
+            <widget class="QLabel" name="label_879">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="12" column="0">
+            <widget class="QLabel" name="label_880">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="13" column="0">
+            <widget class="QLabel" name="label_881">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="14" column="0">
+            <widget class="QLabel" name="label_882">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="15" column="0">
+            <widget class="QLabel" name="label_883">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="16" column="0">
+            <widget class="QLabel" name="label_884">
+             <property name="text">
+              <string>Input</string>
              </property>
             </widget>
            </item>
@@ -13175,7 +13559,7 @@ The Smart Serial Card configuration will not load from the ini file at this time
         <item row="0" column="0">
          <widget class="QTabWidget" name="tabWidget_2">
           <property name="currentIndex">
-           <number>1</number>
+           <number>0</number>
           </property>
           <widget class="QWidget" name="tab_4">
            <attribute name="title">
@@ -13188,115 +13572,195 @@ The Smart Serial Card configuration will not load from the ini file at this time
                <string>TB1</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_42">
-               <item row="0" column="0">
+               <item row="0" column="1">
                 <widget class="QLabel" name="label_283">
                  <property name="text">
-                  <string>Pin 8</string>
+                  <string>8</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="0">
+               <item row="1" column="1">
                 <widget class="QLabel" name="label_284">
                  <property name="text">
-                  <string>Pin 7</string>
+                  <string>7</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="0">
+               <item row="2" column="1">
                 <widget class="QLabel" name="label_285">
                  <property name="text">
-                  <string>Pin 6</string>
+                  <string>6</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="0">
+               <item row="3" column="1">
                 <widget class="QLabel" name="label_286">
                  <property name="text">
-                  <string>Pin 5</string>
+                  <string>5</string>
                  </property>
                 </widget>
                </item>
-               <item row="4" column="0">
+               <item row="4" column="1">
                 <widget class="QLabel" name="label_287">
                  <property name="text">
-                  <string>Pin 4</string>
+                  <string>4</string>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="0">
+               <item row="5" column="1">
                 <widget class="QLabel" name="label_288">
                  <property name="text">
-                  <string>Pin 3</string>
+                  <string>3</string>
                  </property>
                 </widget>
                </item>
-               <item row="6" column="0">
+               <item row="6" column="1">
                 <widget class="QLabel" name="label_289">
                  <property name="text">
-                  <string>Pin 2</string>
+                  <string>2</string>
                  </property>
                 </widget>
                </item>
-               <item row="7" column="0">
+               <item row="7" column="1">
                 <widget class="QLabel" name="label_290">
                  <property name="text">
-                  <string>Pin 1</string>
+                  <string>1</string>
                  </property>
                 </widget>
                </item>
-               <item row="0" column="1">
+               <item row="0" column="2">
                 <widget class="QLabel" name="label_307">
                  <property name="text">
                   <string>Ground</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="1">
+               <item row="1" column="2">
                 <widget class="QLabel" name="label_308">
                  <property name="text">
                   <string>NC</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="1">
+               <item row="2" column="2">
                 <widget class="QLabel" name="label_309">
                  <property name="text">
                   <string>NC</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
+               <item row="3" column="2">
                 <widget class="QLabel" name="label_310">
                  <property name="text">
                   <string>Isolated I/O Power</string>
                  </property>
                 </widget>
                </item>
-               <item row="4" column="1">
+               <item row="4" column="2">
                 <widget class="QLabel" name="label_311">
                  <property name="text">
                   <string>Field Power 8-32v</string>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="1">
+               <item row="5" column="2">
                 <widget class="QLabel" name="label_312">
                  <property name="text">
                   <string>Field Power 8-32v</string>
                  </property>
                 </widget>
                </item>
-               <item row="6" column="1">
+               <item row="6" column="2">
                 <widget class="QLabel" name="label_313">
                  <property name="text">
                   <string>Field Power 8-32v</string>
                  </property>
                 </widget>
                </item>
-               <item row="7" column="1">
+               <item row="7" column="2">
                 <widget class="QLabel" name="label_314">
                  <property name="text">
                   <string>Field Power 8-32v</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_1006">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_1038">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_1052">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="label_1051">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_1053">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="label_1056">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_1054">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_1055">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -13322,339 +13786,579 @@ The Smart Serial Card configuration will not load from the ini file at this time
                <string>TB2</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_43">
-               <item row="2" column="0">
+               <item row="2" column="1">
                 <widget class="QLabel" name="label_315">
                  <property name="text">
-                  <string>Pin 22</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_316">
-                 <property name="text">
-                  <string>Pin 24</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="0">
-                <widget class="QLabel" name="label_317">
-                 <property name="text">
-                  <string>Pin 16</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QLabel" name="label_318">
-                 <property name="text">
-                  <string>Pin 19</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="15" column="0">
-                <widget class="QLabel" name="label_319">
-                 <property name="text">
-                  <string>Pin 9</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_320">
-                 <property name="text">
-                  <string>Pin 20</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="0">
-                <widget class="QLabel" name="label_321">
-                 <property name="text">
-                  <string>Pin 13</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="0">
-                <widget class="QLabel" name="label_322">
-                 <property name="text">
-                  <string>Pin 15</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="0">
-                <widget class="QLabel" name="label_323">
-                 <property name="text">
-                  <string>Pin 11</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="16" column="0">
-                <widget class="QLabel" name="label_324">
-                 <property name="text">
-                  <string>Pin 8</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
-                <widget class="QLabel" name="label_325">
-                 <property name="text">
-                  <string>Pin 18</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="0">
-                <widget class="QLabel" name="label_326">
-                 <property name="text">
-                  <string>Pin 12</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_327">
-                 <property name="text">
-                  <string>Pin 23</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="0">
-                <widget class="QLabel" name="label_328">
-                 <property name="text">
-                  <string>Pin 14</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="label_329">
-                 <property name="text">
-                  <string>Pin 21</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="17" column="0">
-                <widget class="QLabel" name="label_330">
-                 <property name="text">
-                  <string>Pin 7</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="18" column="0">
-                <widget class="QLabel" name="label_331">
-                 <property name="text">
-                  <string>Pin 6</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="19" column="0">
-                <widget class="QLabel" name="label_332">
-                 <property name="text">
-                  <string>Pin 5</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="20" column="0">
-                <widget class="QLabel" name="label_333">
-                 <property name="text">
-                  <string>Pin 4</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="21" column="0">
-                <widget class="QLabel" name="label_334">
-                 <property name="text">
-                  <string>Pin 3</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="22" column="0">
-                <widget class="QLabel" name="label_335">
-                 <property name="text">
-                  <string>Pin 2</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="23" column="0">
-                <widget class="QLabel" name="label_336">
-                 <property name="text">
-                  <string>Pin 1</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="0">
-                <widget class="QLabel" name="label_337">
-                 <property name="text">
-                  <string>Pin 10</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="0">
-                <widget class="QLabel" name="label_338">
-                 <property name="text">
-                  <string>Pin 17</string>
+                  <string>22</string>
                  </property>
                 </widget>
                </item>
                <item row="0" column="1">
+                <widget class="QLabel" name="label_316">
+                 <property name="text">
+                  <string>24</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="label_317">
+                 <property name="text">
+                  <string>16</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="label_318">
+                 <property name="text">
+                  <string>19</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="1">
+                <widget class="QLabel" name="label_319">
+                 <property name="text">
+                  <string>9</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="label_320">
+                 <property name="text">
+                  <string>20</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QLabel" name="label_321">
+                 <property name="text">
+                  <string>13</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="label_322">
+                 <property name="text">
+                  <string>15</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="1">
+                <widget class="QLabel" name="label_323">
+                 <property name="text">
+                  <string>11</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="1">
+                <widget class="QLabel" name="label_324">
+                 <property name="text">
+                  <string>8</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="label_325">
+                 <property name="text">
+                  <string>18</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="1">
+                <widget class="QLabel" name="label_326">
+                 <property name="text">
+                  <string>12</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="label_327">
+                 <property name="text">
+                  <string>23</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QLabel" name="label_328">
+                 <property name="text">
+                  <string>14</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="label_329">
+                 <property name="text">
+                  <string>21</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="1">
+                <widget class="QLabel" name="label_330">
+                 <property name="text">
+                  <string>7</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="1">
+                <widget class="QLabel" name="label_331">
+                 <property name="text">
+                  <string>6</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="1">
+                <widget class="QLabel" name="label_332">
+                 <property name="text">
+                  <string>5</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="1">
+                <widget class="QLabel" name="label_333">
+                 <property name="text">
+                  <string>4</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="1">
+                <widget class="QLabel" name="label_334">
+                 <property name="text">
+                  <string>3</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="1">
+                <widget class="QLabel" name="label_335">
+                 <property name="text">
+                  <string>2</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="1">
+                <widget class="QLabel" name="label_336">
+                 <property name="text">
+                  <string>1</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="1">
+                <widget class="QLabel" name="label_337">
+                 <property name="text">
+                  <string>10</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="label_338">
+                 <property name="text">
+                  <string>17</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
                 <widget class="QLabel" name="label_339">
                  <property name="text">
                   <string>+5v</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="1">
+               <item row="1" column="2">
                 <widget class="QLabel" name="label_340">
                  <property name="text">
                   <string>Direction 3 +</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="1">
+               <item row="2" column="2">
                 <widget class="QLabel" name="label_341">
                  <property name="text">
                   <string>Direction 3 -</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
+               <item row="3" column="2">
                 <widget class="QLabel" name="label_342">
                  <property name="text">
                   <string>Step 3 +</string>
                  </property>
                 </widget>
                </item>
-               <item row="4" column="1">
+               <item row="4" column="2">
                 <widget class="QLabel" name="label_343">
                  <property name="text">
                   <string>Step 3-</string>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="1">
+               <item row="5" column="2">
                 <widget class="QLabel" name="label_344">
                  <property name="text">
                   <string>Ground</string>
                  </property>
                 </widget>
                </item>
-               <item row="6" column="1">
+               <item row="6" column="2">
                 <widget class="QLabel" name="label_345">
                  <property name="text">
                   <string>+5V</string>
                  </property>
                 </widget>
                </item>
-               <item row="7" column="1">
+               <item row="7" column="2">
                 <widget class="QLabel" name="label_346">
                  <property name="text">
                   <string>Direction 2 +_</string>
                  </property>
                 </widget>
                </item>
-               <item row="8" column="1">
+               <item row="8" column="2">
                 <widget class="QLabel" name="label_347">
                  <property name="text">
                   <string>Direction 2 -</string>
                  </property>
                 </widget>
                </item>
-               <item row="9" column="1">
+               <item row="9" column="2">
                 <widget class="QLabel" name="label_348">
                  <property name="text">
                   <string>Step 2 +</string>
                  </property>
                 </widget>
                </item>
-               <item row="10" column="1">
+               <item row="10" column="2">
                 <widget class="QLabel" name="label_349">
                  <property name="text">
                   <string>Step 2 -</string>
                  </property>
                 </widget>
                </item>
-               <item row="11" column="1">
+               <item row="11" column="2">
                 <widget class="QLabel" name="label_350">
                  <property name="text">
                   <string>Ground</string>
                  </property>
                 </widget>
                </item>
-               <item row="12" column="1">
+               <item row="12" column="2">
                 <widget class="QLabel" name="label_351">
                  <property name="text">
                   <string>+5v</string>
                  </property>
                 </widget>
                </item>
-               <item row="13" column="1">
+               <item row="13" column="2">
                 <widget class="QLabel" name="label_352">
                  <property name="text">
                   <string>Direction 1 +</string>
                  </property>
                 </widget>
                </item>
-               <item row="14" column="1">
+               <item row="14" column="2">
                 <widget class="QLabel" name="label_353">
                  <property name="text">
                   <string>Direction 1 -</string>
                  </property>
                 </widget>
                </item>
-               <item row="15" column="1">
+               <item row="15" column="2">
                 <widget class="QLabel" name="label_354">
                  <property name="text">
                   <string>Step 1 +</string>
                  </property>
                 </widget>
                </item>
-               <item row="16" column="1">
+               <item row="16" column="2">
                 <widget class="QLabel" name="label_355">
                  <property name="text">
                   <string>Step 1 -</string>
                  </property>
                 </widget>
                </item>
-               <item row="17" column="1">
+               <item row="17" column="2">
                 <widget class="QLabel" name="label_356">
                  <property name="text">
                   <string>Ground</string>
                  </property>
                 </widget>
                </item>
-               <item row="18" column="1">
+               <item row="18" column="2">
                 <widget class="QLabel" name="label_357">
                  <property name="text">
                   <string>+5v</string>
                  </property>
                 </widget>
                </item>
-               <item row="19" column="1">
+               <item row="19" column="2">
                 <widget class="QLabel" name="tb2p5LB">
                  <property name="text">
                   <string>Direction 0 +</string>
                  </property>
                 </widget>
                </item>
-               <item row="20" column="1">
+               <item row="20" column="2">
                 <widget class="QLabel" name="tb2p4LB">
                  <property name="text">
                   <string>Direction 0 -</string>
                  </property>
                 </widget>
                </item>
-               <item row="21" column="1">
+               <item row="21" column="2">
                 <widget class="QLabel" name="tb2p3LB">
                  <property name="text">
                   <string>Step 0 +</string>
                  </property>
                 </widget>
                </item>
-               <item row="22" column="1">
+               <item row="22" column="2">
                 <widget class="QLabel" name="tb2p2LB">
                  <property name="text">
                   <string>Step 0 -</string>
                  </property>
                 </widget>
                </item>
-               <item row="23" column="1">
+               <item row="23" column="2">
                 <widget class="QLabel" name="label_362">
                  <property name="text">
                   <string>Ground</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_976">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_977">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="label_978">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_979">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_980">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_981">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_982">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="label_983">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="label_984">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="label_985">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="label_986">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="label_987">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="0">
+                <widget class="QLabel" name="label_988">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="0">
+                <widget class="QLabel" name="label_989">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="0">
+                <widget class="QLabel" name="label_990">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="0">
+                <widget class="QLabel" name="label_991">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="0">
+                <widget class="QLabel" name="label_992">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="0">
+                <widget class="QLabel" name="label_993">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="0">
+                <widget class="QLabel" name="label_994">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="0">
+                <widget class="QLabel" name="label_995">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="0">
+                <widget class="QLabel" name="label_996">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="0">
+                <widget class="QLabel" name="label_997">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="0">
+                <widget class="QLabel" name="label_998">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="0">
+                <widget class="QLabel" name="label_999">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -13667,339 +14371,579 @@ The Smart Serial Card configuration will not load from the ini file at this time
                <string>TB3</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_44">
-               <item row="2" column="0">
+               <item row="11" column="0">
+                <widget class="QLabel" name="label_1011">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
                 <widget class="QLabel" name="label_363">
                  <property name="text">
-                  <string>Pin 22</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_364">
-                 <property name="text">
-                  <string>Pin 24</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="0">
-                <widget class="QLabel" name="label_365">
-                 <property name="text">
-                  <string>Pin 16</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QLabel" name="label_366">
-                 <property name="text">
-                  <string>Pin 19</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="15" column="0">
-                <widget class="QLabel" name="label_367">
-                 <property name="text">
-                  <string>Pin 9</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_368">
-                 <property name="text">
-                  <string>Pin 20</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="0">
-                <widget class="QLabel" name="label_369">
-                 <property name="text">
-                  <string>Pin 13</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="0">
-                <widget class="QLabel" name="label_370">
-                 <property name="text">
-                  <string>Pin 15</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="0">
-                <widget class="QLabel" name="label_371">
-                 <property name="text">
-                  <string>Pin 11</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="16" column="0">
-                <widget class="QLabel" name="label_372">
-                 <property name="text">
-                  <string>Pin 8</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
-                <widget class="QLabel" name="label_373">
-                 <property name="text">
-                  <string>Pin 18</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="0">
-                <widget class="QLabel" name="label_374">
-                 <property name="text">
-                  <string>Pin 12</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_375">
-                 <property name="text">
-                  <string>Pin 23</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="0">
-                <widget class="QLabel" name="label_376">
-                 <property name="text">
-                  <string>Pin 14</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="label_377">
-                 <property name="text">
-                  <string>Pin 21</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="17" column="0">
-                <widget class="QLabel" name="label_378">
-                 <property name="text">
-                  <string>Pin 7</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="18" column="0">
-                <widget class="QLabel" name="label_379">
-                 <property name="text">
-                  <string>Pin 6</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="19" column="0">
-                <widget class="QLabel" name="label_380">
-                 <property name="text">
-                  <string>Pin 5</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="20" column="0">
-                <widget class="QLabel" name="label_381">
-                 <property name="text">
-                  <string>Pin 4</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="21" column="0">
-                <widget class="QLabel" name="label_382">
-                 <property name="text">
-                  <string>Pin 3</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="22" column="0">
-                <widget class="QLabel" name="label_383">
-                 <property name="text">
-                  <string>Pin 2</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="23" column="0">
-                <widget class="QLabel" name="label_384">
-                 <property name="text">
-                  <string>Pin 1</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="0">
-                <widget class="QLabel" name="label_385">
-                 <property name="text">
-                  <string>Pin 10</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="0">
-                <widget class="QLabel" name="label_386">
-                 <property name="text">
-                  <string>Pin 17</string>
+                  <string>22</string>
                  </property>
                 </widget>
                </item>
                <item row="0" column="1">
+                <widget class="QLabel" name="label_364">
+                 <property name="text">
+                  <string>24</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="label_365">
+                 <property name="text">
+                  <string>16</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="label_366">
+                 <property name="text">
+                  <string>19</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="1">
+                <widget class="QLabel" name="label_367">
+                 <property name="text">
+                  <string>9</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="label_368">
+                 <property name="text">
+                  <string>20</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="1">
+                <widget class="QLabel" name="label_369">
+                 <property name="text">
+                  <string>13</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QLabel" name="label_370">
+                 <property name="text">
+                  <string>15</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="1">
+                <widget class="QLabel" name="label_371">
+                 <property name="text">
+                  <string>11</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="1">
+                <widget class="QLabel" name="label_372">
+                 <property name="text">
+                  <string>8</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="label_373">
+                 <property name="text">
+                  <string>18</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="1">
+                <widget class="QLabel" name="label_374">
+                 <property name="text">
+                  <string>12</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="label_375">
+                 <property name="text">
+                  <string>23</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QLabel" name="label_376">
+                 <property name="text">
+                  <string>14</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="label_377">
+                 <property name="text">
+                  <string>21</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="1">
+                <widget class="QLabel" name="label_378">
+                 <property name="text">
+                  <string>7</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="1">
+                <widget class="QLabel" name="label_379">
+                 <property name="text">
+                  <string>6</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="1">
+                <widget class="QLabel" name="label_380">
+                 <property name="text">
+                  <string>5</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="1">
+                <widget class="QLabel" name="label_381">
+                 <property name="text">
+                  <string>4</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="1">
+                <widget class="QLabel" name="label_382">
+                 <property name="text">
+                  <string>3</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="1">
+                <widget class="QLabel" name="label_383">
+                 <property name="text">
+                  <string>2</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="24" column="1">
+                <widget class="QLabel" name="label_384">
+                 <property name="text">
+                  <string>1</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="1">
+                <widget class="QLabel" name="label_385">
+                 <property name="text">
+                  <string>10</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="label_386">
+                 <property name="text">
+                  <string>17</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
                 <widget class="QLabel" name="label_387">
                  <property name="text">
                   <string>Ground</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="1">
+               <item row="1" column="2">
                 <widget class="QLabel" name="label_388">
                  <property name="text">
                   <string>Ground</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="1">
+               <item row="2" column="2">
                 <widget class="QLabel" name="label_389">
                  <property name="text">
                   <string>Logic Power + In</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
+               <item row="3" column="2">
                 <widget class="QLabel" name="label_390">
                  <property name="text">
                   <string>Logic Power + In</string>
                  </property>
                 </widget>
                </item>
-               <item row="4" column="1">
+               <item row="4" column="2">
                 <widget class="QLabel" name="label_391">
                  <property name="text">
                   <string>+5v</string>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="1">
+               <item row="5" column="2">
                 <widget class="QLabel" name="label_392">
                  <property name="text">
                   <string>RS-422 TX-</string>
                  </property>
                 </widget>
                </item>
-               <item row="6" column="1">
+               <item row="6" column="2">
                 <widget class="QLabel" name="label_393">
                  <property name="text">
                   <string>RS-422 TX +</string>
                  </property>
                 </widget>
                </item>
-               <item row="7" column="1">
+               <item row="7" column="2">
                 <widget class="QLabel" name="label_394">
                  <property name="text">
                   <string>RS-422 RX -</string>
                  </property>
                 </widget>
                </item>
-               <item row="8" column="1">
+               <item row="9" column="2">
                 <widget class="QLabel" name="label_395">
                  <property name="text">
                   <string>RS-422 RX +</string>
                  </property>
                 </widget>
                </item>
-               <item row="9" column="1">
+               <item row="10" column="2">
                 <widget class="QLabel" name="label_396">
                  <property name="text">
                   <string>Ground</string>
                  </property>
                 </widget>
                </item>
-               <item row="10" column="1">
+               <item row="11" column="2">
                 <widget class="QLabel" name="label_397">
                  <property name="text">
                   <string>Encoder Index -</string>
                  </property>
                 </widget>
                </item>
-               <item row="11" column="1">
+               <item row="12" column="2">
                 <widget class="QLabel" name="label_398">
                  <property name="text">
                   <string>Encoder Index +</string>
                  </property>
                 </widget>
                </item>
-               <item row="12" column="1">
+               <item row="13" column="2">
                 <widget class="QLabel" name="label_399">
                  <property name="text">
                   <string>+5v</string>
                  </property>
                 </widget>
                </item>
-               <item row="13" column="1">
+               <item row="14" column="2">
                 <widget class="QLabel" name="label_400">
                  <property name="text">
                   <string>Encoder B -</string>
                  </property>
                 </widget>
                </item>
-               <item row="14" column="1">
+               <item row="15" column="2">
                 <widget class="QLabel" name="label_401">
                  <property name="text">
                   <string>Encoder B +</string>
                  </property>
                 </widget>
                </item>
-               <item row="15" column="1">
+               <item row="16" column="2">
                 <widget class="QLabel" name="label_402">
                  <property name="text">
                   <string>Ground</string>
                  </property>
                 </widget>
                </item>
-               <item row="16" column="1">
+               <item row="17" column="2">
                 <widget class="QLabel" name="label_403">
                  <property name="text">
                   <string>Encoder A -</string>
                  </property>
                 </widget>
                </item>
-               <item row="17" column="1">
+               <item row="18" column="2">
                 <widget class="QLabel" name="label_404">
                  <property name="text">
                   <string>Encoder A +</string>
                  </property>
                 </widget>
                </item>
-               <item row="18" column="1">
+               <item row="19" column="2">
                 <widget class="QLabel" name="label_405">
                  <property name="text">
                   <string>+5v</string>
                  </property>
                 </widget>
                </item>
-               <item row="19" column="1">
+               <item row="20" column="2">
                 <widget class="QLabel" name="label_406">
                  <property name="text">
                   <string>Direction 4 +</string>
                  </property>
                 </widget>
                </item>
-               <item row="20" column="1">
+               <item row="21" column="2">
                 <widget class="QLabel" name="label_407">
                  <property name="text">
                   <string>Direction 4 -</string>
                  </property>
                 </widget>
                </item>
-               <item row="21" column="1">
+               <item row="22" column="2">
                 <widget class="QLabel" name="label_408">
                  <property name="text">
                   <string>Step 4 +</string>
                  </property>
                 </widget>
                </item>
-               <item row="22" column="1">
+               <item row="23" column="2">
                 <widget class="QLabel" name="label_409">
                  <property name="text">
                   <string>Step 4 -</string>
                  </property>
                 </widget>
                </item>
-               <item row="23" column="1">
+               <item row="24" column="2">
                 <widget class="QLabel" name="label_410">
                  <property name="text">
                   <string>Ground</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="0">
+                <widget class="QLabel" name="label_1036">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="0">
+                <widget class="QLabel" name="label_1037">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="label_1008">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="label_1009">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_1003">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_1004">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="0">
+                <widget class="QLabel" name="label_1042">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_1007">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_1005">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_1001">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="label_1010">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="0">
+                <widget class="QLabel" name="label_1040">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="0">
+                <widget class="QLabel" name="label_1048">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="0">
+                <widget class="QLabel" name="label_1041">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="0">
+                <widget class="QLabel" name="label_1045">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="0">
+                <widget class="QLabel" name="label_1044">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="0">
+                <widget class="QLabel" name="label_1047">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="label_1002">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="0">
+                <widget class="QLabel" name="label_1046">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="24" column="0">
+                <widget class="QLabel" name="label_1049">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="0">
+                <widget class="QLabel" name="label_1039">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="0">
+                <widget class="QLabel" name="label_1043">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_1000">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -14019,115 +14963,195 @@ The Smart Serial Card configuration will not load from the ini file at this time
                <string>TB4</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_52">
-               <item row="0" column="0">
+               <item row="0" column="1">
                 <widget class="QLabel" name="label_444">
                  <property name="text">
-                  <string>Pin 8</string>
+                  <string>8</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="1">
+               <item row="2" column="2">
                 <widget class="QLabel" name="label_473">
                  <property name="text">
                   <string>Spindle Enable +</string>
                  </property>
                 </widget>
                </item>
-               <item row="4" column="1">
+               <item row="4" column="2">
                 <widget class="QLabel" name="label_475">
                  <property name="text">
                   <string>NC</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
+               <item row="3" column="2">
                 <widget class="QLabel" name="label_474">
                  <property name="text">
                   <string>Spindle Enable -</string>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="1">
+               <item row="5" column="2">
                 <widget class="QLabel" name="label_476">
                  <property name="text">
                   <string>Spindle +</string>
                  </property>
                 </widget>
                </item>
-               <item row="6" column="1">
+               <item row="6" column="2">
                 <widget class="QLabel" name="label_477">
                  <property name="text">
                   <string>Spindle Out</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="0">
+               <item row="1" column="1">
                 <widget class="QLabel" name="label_450">
                  <property name="text">
-                  <string>Pin 7</string>
+                  <string>7</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="0">
+               <item row="2" column="1">
                 <widget class="QLabel" name="label_451">
                  <property name="text">
-                  <string>Pin 6</string>
+                  <string>6</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="0">
+               <item row="3" column="1">
                 <widget class="QLabel" name="label_452">
                  <property name="text">
-                  <string>Pin 5</string>
+                  <string>5</string>
                  </property>
                 </widget>
                </item>
-               <item row="4" column="0">
+               <item row="4" column="1">
                 <widget class="QLabel" name="label_453">
                  <property name="text">
-                  <string>Pin 4</string>
+                  <string>4</string>
                  </property>
                 </widget>
                </item>
-               <item row="6" column="0">
+               <item row="6" column="1">
                 <widget class="QLabel" name="label_455">
                  <property name="text">
-                  <string>Pin 2</string>
+                  <string>2</string>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="0">
+               <item row="5" column="1">
                 <widget class="QLabel" name="label_454">
                  <property name="text">
-                  <string>Pin 3</string>
+                  <string>3</string>
                  </property>
                 </widget>
                </item>
-               <item row="7" column="0">
+               <item row="7" column="1">
                 <widget class="QLabel" name="label_456">
                  <property name="text">
-                  <string>Pin 1</string>
+                  <string>1</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="1">
+               <item row="1" column="2">
                 <widget class="QLabel" name="label_472">
                  <property name="text">
                   <string>Spindle Direction -</string>
                  </property>
                 </widget>
                </item>
-               <item row="0" column="1">
+               <item row="0" column="2">
                 <widget class="QLabel" name="label_471">
                  <property name="text">
                   <string>Spindle Direction +</string>
                  </property>
                 </widget>
                </item>
-               <item row="7" column="1">
+               <item row="7" column="2">
                 <widget class="QLabel" name="label_478">
                  <property name="text">
                   <string>Spindle -</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_941">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_942">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="label_943">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_944">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_945">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_946">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_947">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="label_948">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -14153,339 +15177,819 @@ The Smart Serial Card configuration will not load from the ini file at this time
                <string>TB5</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_53">
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_435">
+               <item row="14" column="2">
+                <widget class="QLabel" name="label_931">
                  <property name="text">
-                  <string>Pin 22</string>
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_436">
+               <item row="0" column="2">
+                <widget class="QLabel" name="label_917">
                  <property name="text">
-                  <string>Pin 24</string>
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
-               <item row="8" column="0">
-                <widget class="QLabel" name="label_437">
+               <item row="1" column="2">
+                <widget class="QLabel" name="label_919">
                  <property name="text">
-                  <string>Pin 16</string>
+                  <string>Output</string>
                  </property>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QLabel" name="label_438">
-                 <property name="text">
-                  <string>Pin 19</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="15" column="0">
-                <widget class="QLabel" name="label_439">
-                 <property name="text">
-                  <string>Pin 9</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_440">
-                 <property name="text">
-                  <string>Pin 20</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="0">
-                <widget class="QLabel" name="label_441">
-                 <property name="text">
-                  <string>Pin 13</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="0">
-                <widget class="QLabel" name="label_442">
-                 <property name="text">
-                  <string>Pin 15</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="0">
-                <widget class="QLabel" name="label_443">
-                 <property name="text">
-                  <string>Pin 11</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="16" column="0">
-                <widget class="QLabel" name="label_445">
-                 <property name="text">
-                  <string>Pin 8</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
-                <widget class="QLabel" name="label_446">
-                 <property name="text">
-                  <string>Pin 18</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="0">
-                <widget class="QLabel" name="label_447">
-                 <property name="text">
-                  <string>Pin 12</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_448">
-                 <property name="text">
-                  <string>Pin 23</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="0">
-                <widget class="QLabel" name="label_449">
-                 <property name="text">
-                  <string>Pin 14</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="label_457">
-                 <property name="text">
-                  <string>Pin 21</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="17" column="0">
-                <widget class="QLabel" name="label_458">
-                 <property name="text">
-                  <string>Pin 7</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="18" column="0">
-                <widget class="QLabel" name="label_459">
-                 <property name="text">
-                  <string>Pin 6</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="19" column="0">
-                <widget class="QLabel" name="label_460">
-                 <property name="text">
-                  <string>Pin 5</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="20" column="0">
-                <widget class="QLabel" name="label_461">
-                 <property name="text">
-                  <string>Pin 4</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="21" column="0">
-                <widget class="QLabel" name="label_462">
-                 <property name="text">
-                  <string>Pin 3</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="22" column="0">
-                <widget class="QLabel" name="label_463">
-                 <property name="text">
-                  <string>Pin 2</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="23" column="0">
-                <widget class="QLabel" name="label_464">
-                 <property name="text">
-                  <string>Pin 1</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="0">
-                <widget class="QLabel" name="label_465">
-                 <property name="text">
-                  <string>Pin 10</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="0">
-                <widget class="QLabel" name="label_466">
-                 <property name="text">
-                  <string>Pin 17</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QLabel" name="label_467">
-                 <property name="text">
-                  <string>Output 7</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QLabel" name="label_468">
-                 <property name="text">
-                  <string>Output 6</string>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
                <item row="2" column="1">
-                <widget class="QLabel" name="label_469">
+                <widget class="QLabel" name="label_435">
                  <property name="text">
-                  <string>Output 5</string>
+                  <string>22</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
-                <widget class="QLabel" name="label_470">
+               <item row="0" column="1">
+                <widget class="QLabel" name="label_436">
                  <property name="text">
-                  <string>Output 4</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="QLabel" name="label_479">
-                 <property name="text">
-                  <string>Output 3</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="1">
-                <widget class="QLabel" name="label_480">
-                 <property name="text">
-                  <string>Output 2</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="1">
-                <widget class="QLabel" name="label_481">
-                 <property name="text">
-                  <string>Output 1</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="1">
-                <widget class="QLabel" name="label_482">
-                 <property name="text">
-                  <string>Output 0</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="1">
-                <widget class="QLabel" name="label_483">
-                 <property name="text">
-                  <string>Input 15</string>
+                  <string>24</string>
                  </property>
                 </widget>
                </item>
                <item row="9" column="1">
-                <widget class="QLabel" name="label_484">
+                <widget class="QLabel" name="label_437">
                  <property name="text">
-                  <string>Input 14</string>
+                  <string>16</string>
                  </property>
                 </widget>
                </item>
-               <item row="10" column="1">
-                <widget class="QLabel" name="label_485">
+               <item row="5" column="1">
+                <widget class="QLabel" name="label_438">
                  <property name="text">
-                  <string>Input 13</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="1">
-                <widget class="QLabel" name="label_486">
-                 <property name="text">
-                  <string>Input 12</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="1">
-                <widget class="QLabel" name="label_487">
-                 <property name="text">
-                  <string>Input 11</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="1">
-                <widget class="QLabel" name="label_488">
-                 <property name="text">
-                  <string>Input 10</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="1">
-                <widget class="QLabel" name="label_489">
-                 <property name="text">
-                  <string>Input 9</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="15" column="1">
-                <widget class="QLabel" name="label_490">
-                 <property name="text">
-                  <string>Input 8</string>
+                  <string>19</string>
                  </property>
                 </widget>
                </item>
                <item row="16" column="1">
-                <widget class="QLabel" name="label_491">
+                <widget class="QLabel" name="label_439">
                  <property name="text">
-                  <string>Input 7</string>
+                  <string>9</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="label_440">
+                 <property name="text">
+                  <string>20</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="1">
+                <widget class="QLabel" name="label_441">
+                 <property name="text">
+                  <string>13</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QLabel" name="label_442">
+                 <property name="text">
+                  <string>15</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="1">
+                <widget class="QLabel" name="label_443">
+                 <property name="text">
+                  <string>11</string>
                  </property>
                 </widget>
                </item>
                <item row="17" column="1">
-                <widget class="QLabel" name="label_492">
+                <widget class="QLabel" name="label_445">
                  <property name="text">
-                  <string>Input 6</string>
+                  <string>8</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="label_446">
+                 <property name="text">
+                  <string>18</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="1">
+                <widget class="QLabel" name="label_447">
+                 <property name="text">
+                  <string>12</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="label_448">
+                 <property name="text">
+                  <string>23</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QLabel" name="label_449">
+                 <property name="text">
+                  <string>14</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="label_457">
+                 <property name="text">
+                  <string>21</string>
                  </property>
                 </widget>
                </item>
                <item row="18" column="1">
-                <widget class="QLabel" name="label_493">
+                <widget class="QLabel" name="label_458">
                  <property name="text">
-                  <string>Input 5</string>
+                  <string>7</string>
                  </property>
                 </widget>
                </item>
                <item row="19" column="1">
-                <widget class="QLabel" name="label_494">
+                <widget class="QLabel" name="label_459">
                  <property name="text">
-                  <string>Input 4</string>
+                  <string>6</string>
                  </property>
                 </widget>
                </item>
                <item row="20" column="1">
-                <widget class="QLabel" name="label_495">
+                <widget class="QLabel" name="label_460">
                  <property name="text">
-                  <string>Input 3</string>
+                  <string>5</string>
                  </property>
                 </widget>
                </item>
                <item row="21" column="1">
-                <widget class="QLabel" name="label_496">
+                <widget class="QLabel" name="label_461">
                  <property name="text">
-                  <string>Input 2</string>
+                  <string>4</string>
                  </property>
                 </widget>
                </item>
                <item row="22" column="1">
-                <widget class="QLabel" name="label_497">
+                <widget class="QLabel" name="label_462">
                  <property name="text">
-                  <string>Input 1</string>
+                  <string>3</string>
                  </property>
                 </widget>
                </item>
                <item row="23" column="1">
+                <widget class="QLabel" name="label_463">
+                 <property name="text">
+                  <string>2</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="24" column="1">
+                <widget class="QLabel" name="label_464">
+                 <property name="text">
+                  <string>1</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="1">
+                <widget class="QLabel" name="label_465">
+                 <property name="text">
+                  <string>10</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="label_466">
+                 <property name="text">
+                  <string>17</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <widget class="QLabel" name="label_467">
+                 <property name="text">
+                  <string>7</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="3">
+                <widget class="QLabel" name="label_468">
+                 <property name="text">
+                  <string>6</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="3">
+                <widget class="QLabel" name="label_469">
+                 <property name="text">
+                  <string>5</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="3">
+                <widget class="QLabel" name="label_470">
+                 <property name="text">
+                  <string>4</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="3">
+                <widget class="QLabel" name="label_479">
+                 <property name="text">
+                  <string>3</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="3">
+                <widget class="QLabel" name="label_480">
+                 <property name="text">
+                  <string>2</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="3">
+                <widget class="QLabel" name="label_481">
+                 <property name="text">
+                  <string>1</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="3">
+                <widget class="QLabel" name="label_482">
+                 <property name="text">
+                  <string>0</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="3">
+                <widget class="QLabel" name="label_483">
+                 <property name="text">
+                  <string>15</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="3">
+                <widget class="QLabel" name="label_484">
+                 <property name="text">
+                  <string>14</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="3">
+                <widget class="QLabel" name="label_485">
+                 <property name="text">
+                  <string>13</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="3">
+                <widget class="QLabel" name="label_486">
+                 <property name="text">
+                  <string>12</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="3">
+                <widget class="QLabel" name="label_487">
+                 <property name="text">
+                  <string>11</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="3">
+                <widget class="QLabel" name="label_488">
+                 <property name="text">
+                  <string>10</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="3">
+                <widget class="QLabel" name="label_489">
+                 <property name="text">
+                  <string>9</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="3">
+                <widget class="QLabel" name="label_490">
+                 <property name="text">
+                  <string>8</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="3">
+                <widget class="QLabel" name="label_491">
+                 <property name="text">
+                  <string>7</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="3">
+                <widget class="QLabel" name="label_492">
+                 <property name="text">
+                  <string>6</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="3">
+                <widget class="QLabel" name="label_493">
+                 <property name="text">
+                  <string>5</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="3">
+                <widget class="QLabel" name="label_494">
+                 <property name="text">
+                  <string>4</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="3">
+                <widget class="QLabel" name="label_495">
+                 <property name="text">
+                  <string>3</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="3">
+                <widget class="QLabel" name="label_496">
+                 <property name="text">
+                  <string>2</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="3">
+                <widget class="QLabel" name="label_497">
+                 <property name="text">
+                  <string>1</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="24" column="3">
                 <widget class="QLabel" name="label_498">
                  <property name="text">
-                  <string>Input 0</string>
+                  <string>0</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="2">
+                <widget class="QLabel" name="label_932">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="2">
+                <widget class="QLabel" name="label_935">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="2">
+                <widget class="QLabel" name="label_939">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="2">
+                <widget class="QLabel" name="label_927">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="2">
+                <widget class="QLabel" name="label_922">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="2">
+                <widget class="QLabel" name="label_925">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="2">
+                <widget class="QLabel" name="label_930">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="2">
+                <widget class="QLabel" name="label_921">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="2">
+                <widget class="QLabel" name="label_933">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="2">
+                <widget class="QLabel" name="label_934">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="2">
+                <widget class="QLabel" name="label_929">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <widget class="QLabel" name="label_920">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="2">
+                <widget class="QLabel" name="label_937">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="2">
+                <widget class="QLabel" name="label_923">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="2">
+                <widget class="QLabel" name="label_926">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="2">
+                <widget class="QLabel" name="label_928">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="2">
+                <widget class="QLabel" name="label_940">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="2">
+                <widget class="QLabel" name="label_938">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="2">
+                <widget class="QLabel" name="label_924">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="2">
+                <widget class="QLabel" name="label_936">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="24" column="2">
+                <widget class="QLabel" name="label_1012">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="label_951">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_952">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="label_957">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="label_956">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_950">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_954">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_949">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_953">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="label_955">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="label_958">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="label_959">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="0">
+                <widget class="QLabel" name="label_960">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="0">
+                <widget class="QLabel" name="label_961">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="0">
+                <widget class="QLabel" name="label_962">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="0">
+                <widget class="QLabel" name="label_963">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="0">
+                <widget class="QLabel" name="label_964">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="0">
+                <widget class="QLabel" name="label_965">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="0">
+                <widget class="QLabel" name="label_966">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="0">
+                <widget class="QLabel" name="label_967">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="0">
+                <widget class="QLabel" name="label_968">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="0">
+                <widget class="QLabel" name="label_969">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="0">
+                <widget class="QLabel" name="label_970">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="0">
+                <widget class="QLabel" name="label_971">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="24" column="0">
+                <widget class="QLabel" name="label_972">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -14498,339 +16002,819 @@ The Smart Serial Card configuration will not load from the ini file at this time
                <string>TB6</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_54">
-               <item row="2" column="0">
+               <item row="2" column="1">
                 <widget class="QLabel" name="label_499">
                  <property name="text">
-                  <string>Pin 22</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_500">
-                 <property name="text">
-                  <string>Pin 24</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="0">
-                <widget class="QLabel" name="label_501">
-                 <property name="text">
-                  <string>Pin 16</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QLabel" name="label_502">
-                 <property name="text">
-                  <string>Pin 19</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="15" column="0">
-                <widget class="QLabel" name="label_503">
-                 <property name="text">
-                  <string>Pin 9</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_504">
-                 <property name="text">
-                  <string>Pin 20</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="0">
-                <widget class="QLabel" name="label_505">
-                 <property name="text">
-                  <string>Pin 13</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="0">
-                <widget class="QLabel" name="label_506">
-                 <property name="text">
-                  <string>Pin 15</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="0">
-                <widget class="QLabel" name="label_507">
-                 <property name="text">
-                  <string>Pin 11</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="16" column="0">
-                <widget class="QLabel" name="label_508">
-                 <property name="text">
-                  <string>Pin 8</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
-                <widget class="QLabel" name="label_509">
-                 <property name="text">
-                  <string>Pin 18</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="0">
-                <widget class="QLabel" name="label_510">
-                 <property name="text">
-                  <string>Pin 12</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_511">
-                 <property name="text">
-                  <string>Pin 23</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="0">
-                <widget class="QLabel" name="label_512">
-                 <property name="text">
-                  <string>Pin 14</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="label_513">
-                 <property name="text">
-                  <string>Pin 21</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="17" column="0">
-                <widget class="QLabel" name="label_514">
-                 <property name="text">
-                  <string>Pin 7</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="18" column="0">
-                <widget class="QLabel" name="label_515">
-                 <property name="text">
-                  <string>Pin 6</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="19" column="0">
-                <widget class="QLabel" name="label_516">
-                 <property name="text">
-                  <string>Pin 5</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="20" column="0">
-                <widget class="QLabel" name="label_517">
-                 <property name="text">
-                  <string>Pin 4</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="21" column="0">
-                <widget class="QLabel" name="label_518">
-                 <property name="text">
-                  <string>Pin 3</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="22" column="0">
-                <widget class="QLabel" name="label_519">
-                 <property name="text">
-                  <string>Pin 2</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="23" column="0">
-                <widget class="QLabel" name="label_520">
-                 <property name="text">
-                  <string>Pin 1</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="0">
-                <widget class="QLabel" name="label_521">
-                 <property name="text">
-                  <string>Pin 10</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="0">
-                <widget class="QLabel" name="label_522">
-                 <property name="text">
-                  <string>Pin 17</string>
+                  <string>22</string>
                  </property>
                 </widget>
                </item>
                <item row="0" column="1">
-                <widget class="QLabel" name="label_523">
+                <widget class="QLabel" name="label_500">
                  <property name="text">
-                  <string>Output 15</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QLabel" name="label_524">
-                 <property name="text">
-                  <string>Output 14</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <widget class="QLabel" name="label_525">
-                 <property name="text">
-                  <string>Output 13</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="1">
-                <widget class="QLabel" name="label_526">
-                 <property name="text">
-                  <string>Output 12</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="QLabel" name="label_527">
-                 <property name="text">
-                  <string>Output 11</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="1">
-                <widget class="QLabel" name="label_528">
-                 <property name="text">
-                  <string>Output 10</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="1">
-                <widget class="QLabel" name="label_529">
-                 <property name="text">
-                  <string>Output 9</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="1">
-                <widget class="QLabel" name="label_530">
-                 <property name="text">
-                  <string>Output 8</string>
+                  <string>24</string>
                  </property>
                 </widget>
                </item>
                <item row="8" column="1">
-                <widget class="QLabel" name="label_531">
+                <widget class="QLabel" name="label_501">
                  <property name="text">
-                  <string>Input 31</string>
+                  <string>16</string>
                  </property>
                 </widget>
                </item>
-               <item row="9" column="1">
-                <widget class="QLabel" name="label_532">
+               <item row="5" column="1">
+                <widget class="QLabel" name="label_502">
                  <property name="text">
-                  <string>Input 30</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="1">
-                <widget class="QLabel" name="label_533">
-                 <property name="text">
-                  <string>Input 29</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="1">
-                <widget class="QLabel" name="label_534">
-                 <property name="text">
-                  <string>Input 28</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="1">
-                <widget class="QLabel" name="label_535">
-                 <property name="text">
-                  <string>Input 27</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="1">
-                <widget class="QLabel" name="label_536">
-                 <property name="text">
-                  <string>Input 26</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="1">
-                <widget class="QLabel" name="label_537">
-                 <property name="text">
-                  <string>Input 25</string>
+                  <string>19</string>
                  </property>
                 </widget>
                </item>
                <item row="15" column="1">
-                <widget class="QLabel" name="label_538">
+                <widget class="QLabel" name="label_503">
                  <property name="text">
-                  <string>Input 24</string>
+                  <string>9</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="label_504">
+                 <property name="text">
+                  <string>20</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QLabel" name="label_505">
+                 <property name="text">
+                  <string>13</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="label_506">
+                 <property name="text">
+                  <string>15</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="1">
+                <widget class="QLabel" name="label_507">
+                 <property name="text">
+                  <string>11</string>
                  </property>
                 </widget>
                </item>
                <item row="16" column="1">
-                <widget class="QLabel" name="label_539">
+                <widget class="QLabel" name="label_508">
                  <property name="text">
-                  <string>Input 23</string>
+                  <string>8</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="label_509">
+                 <property name="text">
+                  <string>18</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="1">
+                <widget class="QLabel" name="label_510">
+                 <property name="text">
+                  <string>12</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="label_511">
+                 <property name="text">
+                  <string>23</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QLabel" name="label_512">
+                 <property name="text">
+                  <string>14</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="label_513">
+                 <property name="text">
+                  <string>21</string>
                  </property>
                 </widget>
                </item>
                <item row="17" column="1">
-                <widget class="QLabel" name="label_540">
+                <widget class="QLabel" name="label_514">
                  <property name="text">
-                  <string>Input 22</string>
+                  <string>7</string>
                  </property>
                 </widget>
                </item>
                <item row="18" column="1">
-                <widget class="QLabel" name="label_541">
+                <widget class="QLabel" name="label_515">
                  <property name="text">
-                  <string>Input 21</string>
+                  <string>6</string>
                  </property>
                 </widget>
                </item>
                <item row="19" column="1">
-                <widget class="QLabel" name="label_542">
+                <widget class="QLabel" name="label_516">
                  <property name="text">
-                  <string>Input 20</string>
+                  <string>5</string>
                  </property>
                 </widget>
                </item>
                <item row="20" column="1">
-                <widget class="QLabel" name="label_543">
+                <widget class="QLabel" name="label_517">
                  <property name="text">
-                  <string>Input 19</string>
+                  <string>4</string>
                  </property>
                 </widget>
                </item>
                <item row="21" column="1">
-                <widget class="QLabel" name="label_544">
+                <widget class="QLabel" name="label_518">
                  <property name="text">
-                  <string>Input18</string>
+                  <string>3</string>
                  </property>
                 </widget>
                </item>
                <item row="22" column="1">
-                <widget class="QLabel" name="label_545">
+                <widget class="QLabel" name="label_519">
                  <property name="text">
-                  <string>Input 17</string>
+                  <string>2</string>
                  </property>
                 </widget>
                </item>
                <item row="23" column="1">
+                <widget class="QLabel" name="label_520">
+                 <property name="text">
+                  <string>1</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="1">
+                <widget class="QLabel" name="label_521">
+                 <property name="text">
+                  <string>10</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="label_522">
+                 <property name="text">
+                  <string>17</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <widget class="QLabel" name="label_523">
+                 <property name="text">
+                  <string>15</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="3">
+                <widget class="QLabel" name="label_524">
+                 <property name="text">
+                  <string>14</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="3">
+                <widget class="QLabel" name="label_525">
+                 <property name="text">
+                  <string>13</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="3">
+                <widget class="QLabel" name="label_526">
+                 <property name="text">
+                  <string>12</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="3">
+                <widget class="QLabel" name="label_527">
+                 <property name="text">
+                  <string>11</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="3">
+                <widget class="QLabel" name="label_528">
+                 <property name="text">
+                  <string>10</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="3">
+                <widget class="QLabel" name="label_529">
+                 <property name="text">
+                  <string>9</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="3">
+                <widget class="QLabel" name="label_530">
+                 <property name="text">
+                  <string>8</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="3">
+                <widget class="QLabel" name="label_531">
+                 <property name="text">
+                  <string>31</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="3">
+                <widget class="QLabel" name="label_532">
+                 <property name="text">
+                  <string>30</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="3">
+                <widget class="QLabel" name="label_533">
+                 <property name="text">
+                  <string>29</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="3">
+                <widget class="QLabel" name="label_534">
+                 <property name="text">
+                  <string>28</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="3">
+                <widget class="QLabel" name="label_535">
+                 <property name="text">
+                  <string>27</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="3">
+                <widget class="QLabel" name="label_536">
+                 <property name="text">
+                  <string>26</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="3">
+                <widget class="QLabel" name="label_537">
+                 <property name="text">
+                  <string>25</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="3">
+                <widget class="QLabel" name="label_538">
+                 <property name="text">
+                  <string>24</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="3">
+                <widget class="QLabel" name="label_539">
+                 <property name="text">
+                  <string>23</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="3">
+                <widget class="QLabel" name="label_540">
+                 <property name="text">
+                  <string>22</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="3">
+                <widget class="QLabel" name="label_541">
+                 <property name="text">
+                  <string>21</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="3">
+                <widget class="QLabel" name="label_542">
+                 <property name="text">
+                  <string>20</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="3">
+                <widget class="QLabel" name="label_543">
+                 <property name="text">
+                  <string>19</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="3">
+                <widget class="QLabel" name="label_544">
+                 <property name="text">
+                  <string>8</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="3">
+                <widget class="QLabel" name="label_545">
+                 <property name="text">
+                  <string>17</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="3">
                 <widget class="QLabel" name="label_546">
                  <property name="text">
-                  <string>Input 16</string>
+                  <string>16</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QLabel" name="label_1013">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="2">
+                <widget class="QLabel" name="label_1018">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="2">
+                <widget class="QLabel" name="label_1019">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="2">
+                <widget class="QLabel" name="label_1016">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="2">
+                <widget class="QLabel" name="label_1015">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="2">
+                <widget class="QLabel" name="label_1023">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QLabel" name="label_918">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="2">
+                <widget class="QLabel" name="label_1022">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <widget class="QLabel" name="label_1014">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="2">
+                <widget class="QLabel" name="label_1020">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="2">
+                <widget class="QLabel" name="label_1026">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="2">
+                <widget class="QLabel" name="label_1017">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="2">
+                <widget class="QLabel" name="label_1024">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="2">
+                <widget class="QLabel" name="label_1021">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="2">
+                <widget class="QLabel" name="label_1025">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="2">
+                <widget class="QLabel" name="label_1027">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="2">
+                <widget class="QLabel" name="label_1028">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="2">
+                <widget class="QLabel" name="label_1029">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="2">
+                <widget class="QLabel" name="label_1030">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="2">
+                <widget class="QLabel" name="label_1031">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="2">
+                <widget class="QLabel" name="label_1032">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="2">
+                <widget class="QLabel" name="label_1033">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="2">
+                <widget class="QLabel" name="label_1034">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="2">
+                <widget class="QLabel" name="label_1035">
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_1077">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="0">
+                <widget class="QLabel" name="label_1084">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_1076">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_974">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="label_1081">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="label_1082">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_1078">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="0">
+                <widget class="QLabel" name="label_1093">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="0">
+                <widget class="QLabel" name="label_1086">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="label_1080">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_973">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="0">
+                <widget class="QLabel" name="label_1094">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="0">
+                <widget class="QLabel" name="label_1091">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="0">
+                <widget class="QLabel" name="label_1085">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="0">
+                <widget class="QLabel" name="label_1090">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="label_975">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_1075">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="label_1079">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="0">
+                <widget class="QLabel" name="label_1088">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="label_1083">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="0">
+                <widget class="QLabel" name="label_1087">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="0">
+                <widget class="QLabel" name="label_1089">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="0">
+                <widget class="QLabel" name="label_1092">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="0">
+                <widget class="QLabel" name="label_1095">
+                 <property name="text">
+                  <string>Pin</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
Splitting labels like "Pin NN" into two labels with "Pin" and "NN".
Done for Pin, Input, Output.
This reduces the strings to translate by 70.